### PR TITLE
Required variable selection

### DIFF
--- a/app.R
+++ b/app.R
@@ -608,8 +608,8 @@ server <- function(input, output, session) {
                    needs_linekey <- (input$data_type == "lpi" & input$lpi_unit == "line") | (input$data_type == "gap" & input$gap_unit == "line") | (input$data_type == "height" & input$height_unit == "line")
                    if (needs_linekey) {
                      message("Including 'LineKey' in required variables.")
-                     current_required_vars <- c(workspace$required_vars[[input$data_type]],
-                                                "LineKey")
+                     current_required_vars <- unique(c(workspace$required_vars[[input$data_type]],
+                                                       "LineKey"))
                    } else {
                      current_required_vars <- workspace$required_vars[[input$data_type]]
                    }


### PR DESCRIPTION
Allow users to specify which of the variables in their data correspond to the required variables. This updates workspace$data with the correct variable names so that the terradactyl functions can use the data.